### PR TITLE
Update bg_api to deal with separate Job-UUID header

### DIFF
--- a/src/response.coffee.md
+++ b/src/response.coffee.md
@@ -153,6 +153,9 @@ The promise will receive the Job UUID (instead of the usual response).
               if r? and r[1]?
                 resolve res, r[1]
                 return
+              else if (res.headers['Job-UUID']?)
+                resolve(res, res.headers['Job-UUID'])
+                return
               else
                 reject new FreeSwitchError res, {when:"bgapi did not provide a Job-UUID",command}
                 return


### PR DESCRIPTION
I forgot I was carrying this around until I updated to 2.3.0, but figured it would be useful!

When I make a call to bgapi, the resulting object (res) looks like:  
<code>
{ headers: 
   { 'Content-Type': 'command/reply',
     'Reply-Text': '+OK Job-UUID',
     'Job-UUID': '96f09cda-773f-11e4-b046-314aef1416bd' },
  body: undefined }
</code>

When this call is made in fs_cli, it looks like:

<code>
+OK Job-UUID: 53abcbc8-7741-11e4-b049-314aef1416bd
</code>

The code without my patch seems to just check for the fs_cli version. I'm not sure if there is a way to make the result object look like fs_cli output, so I left in the old way as well.
