### PR TITLE
add option to allow see all calls in the socket

### DIFF
--- a/src/esl.coffee.md
+++ b/src/esl.coffee.md
@@ -231,6 +231,7 @@ The call handler will receive a `FreeSwitchResponse` object, `options` are optio
         debug "Server: #{error}"
 
       options.all_events ?= true
+      options.all_calls ?= false
 
       assert.ok handler?, "server handler is required"
       assert.strictEqual typeof handler, 'function', "server handler must be a function"
@@ -251,9 +252,10 @@ Confirm connection with FreeSwitch.
             @data = res.body
             @uuid = @data[Unique_ID]
 
-Restricting events using `filter` is required so that `event_json` will only obtain our events.
+Restricting events using `filter` is required so that `event_json` will only obtain our events unless `all_calls` is set to `true`.
 
-            @filter Unique_ID, @uuid
+            unless options.all_calls
+              @filter Unique_ID, @uuid
           .then ->
             server.stats.handler ?= 0
             server.stats.handler++


### PR DESCRIPTION
Freeswitch allows definition wether to restrict the socket within the call's Events only or to let it subscribe to all:

`If the "full" keyword is absent the command set and events are limited to that particular call.`
https://freeswitch.org/confluence/display/FREESWITCH/Event+Socket+Outbound#EventSocketOutbound-full

The compatibility should be preserved.