### PR TITLE
introduce `FS.reconnect`

### DIFF
--- a/src/response.coffee.md
+++ b/src/response.coffee.md
@@ -8,8 +8,17 @@ Response and associated API
 
     class FreeSwitchError extends Error
       constructor: (@res,@args) ->
-        super JSON.stringify @args
+        super()
         return
+      toString: ->
+        "FreeSwitchError: #{JSON.stringify @args}"
+
+    class FreeSwitchTimeout extends Error
+      constructor: (@timeout,@text) ->
+        super()
+        return
+      toString: ->
+        "FreeSwitchTimeout: Timeout after #{@timeout}ms waiting for #{@text}"
 
     module.exports = class FreeSwitchResponse extends EventEmitter2
 
@@ -73,7 +82,7 @@ Note that this value must be longer than (for exemple) a regular call's duration
 
       default_event_timeout: 9*3600*1000 # 9 hours
 
-      command_timeout: 30*1000 # 30s
+      command_timeout: 10*1000 # 10s
 
 Most commands allow you to specify a timeout.
 
@@ -108,7 +117,7 @@ onceAsync
             trace "onceAsync: on_timeout #{event}"
             return unless p.isPending()
             cleanup()
-            reject.call self, new Error "Timeout after #{timeout}ms waiting for event #{event}"
+            reject.call self, new FreeSwitchTimeout timeout, "event #{event}"
             return
 
           cleanup = ->

--- a/test/0001.coffee.md
+++ b/test/0001.coffee.md
@@ -105,19 +105,6 @@ Test of the `client` part
             .then -> done()
           .connect client_port, '127.0.0.1'
 
-        it 'should reloadxml with keepConnected', (done) ->
-          cmd = 'reloadxml'
-          client = FS.client ->
-            @api cmd
-            .then (res) ->
-              res.body.should.match /\+OK \[Success\]/
-              this
-            .then -> @exit()
-            .then -> client.end()
-            .then -> done()
-          client.keepConnected client_port, '127.0.0.1'
-          return
-
         it 'should properly parse plain events', (done) ->
           @timeout 2000
           cmd = 'event plain ALL'

--- a/test/reconnect.coffee.md
+++ b/test/reconnect.coffee.md
@@ -1,0 +1,82 @@
+    FS = require '../src/esl'
+    pkg = require '../package'
+    debug = (require 'debug') "#{pkg.name}:test:reconnect"
+    net = require 'net'
+    seem = require 'seem'
+    sleep = (timeout) -> new Promise (resolve) -> setTimeout resolve, timeout
+
+    describe 'The client', ->
+      client_port = 5623
+      it 'should reconnect', (done) ->
+        @timeout 30000
+        start = (run = 1) ->
+          service = (c) ->
+            debug "Server run ##{run} received connection"
+            c.on 'error', (error) ->
+              debug "Server run ##{run} received error #{error}"
+              return
+            c.on 'data', seem (data) ->
+              debug "Server run ##{run} received data", data
+              switch run
+                when 1
+                  debug 'Server run #1 sleeping'
+                  yield sleep 500
+                  debug 'Server run #1 close'
+                  yield c.destroy()
+                  yield spoof.close()
+
+                when 2
+                  debug 'Server run #2 writing (auth)'
+                  yield c.write '''
+                    Content-Type: auth/request
+
+
+                  '''
+                  debug 'Server run #2 sleeping'
+                  yield sleep 500
+                  debug 'Server run #2 writing (reply)'
+                  yield c.write '''
+
+                    Content-Type: command/reply
+                    Reply-Text: +OK accepted
+
+                    Content-Type: text/disconnect-notice
+                    Content-Length: 0
+
+                  '''
+                  debug 'Server run #2 sleeping'
+                  yield sleep 500
+                  debug 'Server run #2 close'
+                  yield spoof.close()
+
+                when 3
+                  debug 'Server run #3 close'
+                  yield spoof.close()
+                  done()
+
+            c.resume()
+            c.write '''
+              Content-Type: auth/request
+
+
+            '''
+            return
+
+          spoof = net.createServer service
+          spoof.listen client_port, ->
+            debug "Server run ##{run} ready"
+          spoof.on 'close', ->
+            debug 'Server received close event'
+            run++
+            if run < 4
+              setTimeout (-> start run+1), 1400
+            return
+          return
+
+        after ->
+          stop_client()
+
+        start()
+        stop_client = FS.reconnect {host:'127.0.0.1',port:client_port}, ->
+          debug 'Client is connected'
+          @end()


### PR DESCRIPTION
fixes #44 

The new feature is exported as `reconnect( `[`connect_options`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener)`, [options,] handler [,report] )` and works similarly to `client([options,]handler[,report])` but keeps the connection open. It returns a function which will terminate the connection attempts:
    
```
var stop_client = FS.reconnect({host:'127.0.0.1',port:8021},handler);
…
stop_client()
```