### PR TITLE
Use headers to tracks commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "debug": "^3.1.0",
-    "eventemitter2": "^5.0.0"
+    "eventemitter2": "^5.0.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -56,8 +57,7 @@
     "mocha": "^4.0.1",
     "pouchdb-adapter-memory": "^6.4.1",
     "pouchdb-core": "^6.4.1",
-    "seem": "^2.0.0",
-    "uuid": "^3.1.0"
+    "seem": "^2.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm install --only=dev && rm package-lock.json && coffee -c -o lib/ src/*.coffee.md && docco src/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esl",
-  "version": "8.1.1",
+  "version": "9.0.0-0",
   "description": "Client and Server for FreeSwitch Event System",
   "keywords": [
     "freeswitch",
@@ -60,7 +60,8 @@
     "seem": "^2.0.0"
   },
   "scripts": {
-    "prepublishOnly": "npm install --only=dev && rm package-lock.json && coffee -c -o lib/ src/*.coffee.md && docco src/*",
+    "build": "coffee -c -o lib/ src/*.coffee.md && docco src/*",
+    "prepublishOnly": "npm install --only=dev && rm -f package-lock.json && npm run build",
     "pretest": "npm install && npm run prepublishOnly",
     "test": "(cd test && ./setup.sh) && mocha && (cd test && ./cleanup.sh; exit 0)",
     "test-debug": "(cd test && ./setup.sh) && DEBUG='*,-mocha*' mocha && (cd test && ./cleanup.sh; exit 0)",

--- a/src/esl.coffee.md
+++ b/src/esl.coffee.md
@@ -20,12 +20,8 @@ The parser will be the one receiving the actual data from the socket. We will pr
 Make the command responses somewhat unique. This is required since FreeSwitch doesn't provide us a way to match responses with requests.
 
       call.on 'CHANNEL_EXECUTE_COMPLETE', (res) ->
-        application = res.body['Application']
-        application_data = res.body['Application-Data'] ? ''
-        call.emit "CHANNEL_EXECUTE_COMPLETE #{application} #{application_data}", res
-        unique_id = res.body['Unique-ID']
-        if unique_id?
-          call.emit "CHANNEL_EXECUTE_COMPLETE #{unique_id} #{application} #{application_data}", res
+        event_uuid = res.body['Application-UUID']
+        call.emit "CHANNEL_EXECUTE_COMPLETE #{event_uuid}", res
 
       call.on 'BACKGROUND_JOB', (res) ->
         job_uuid = res.body['Job-UUID']

--- a/test/wrapper.coffee.md
+++ b/test/wrapper.coffee.md
@@ -24,7 +24,6 @@
               yield sleep 100
               debug "Server run ##{run} writing (reply ok)"
               c.write '''
-
                 Content-Type: command/reply
                 Reply-Text: +OK accepted
 
@@ -33,31 +32,36 @@
               if data.match /bridge[^]*foo/
                 yield sleep 100
                 debug "Server run ##{run} writing (execute-complete for bridge)"
-                c.write '''
-
+                event_uuid = data.match(/Event-UUID: (\S+)/)[1]
+                msg = """
                   Content-Type: text/event-plain
-                  Content-Length: 78
+                  Content-Length: #{97+event_uuid.length}
 
                   Event-Name: CHANNEL_EXECUTE_COMPLETE
                   Application: bridge
                   Application-Data: foo
+                  Application-UUID: #{event_uuid}
 
 
-                '''
+                """
+                c.write msg
               if data.match /ping[^]*bar/
                 yield sleep 100
                 debug "Server run ##{run} writing (execute-complete for ping)"
-                c.write '''
+                event_uuid = data.match(/Event-UUID: (\S+)/)[1]
+                msg = """
 
                   Content-Type: text/event-plain
-                  Content-Length: 76
+                  Content-Length: #{95+event_uuid.length}
 
                   Event-Name: CHANNEL_EXECUTE_COMPLETE
                   Application: ping
                   Application-Data: bar
+                  Application-UUID: #{event_uuid}
 
 
-                '''
+                """
+                c.write msg
             c.on 'end', ->
               debug "Server run ##{run} end"
 


### PR DESCRIPTION
Instead of using the parameters to match an `execute` command and its response, it appears we should be able to send an `Event-UUID` header and get it back in the `Application-UUID` header.

The value of the `Event-UUID` header is saved in the `app_uuid` variable (in `switch_ivr.c`) then retrieved (in `switch_core_session.c`) to populate the `Application-UUID` header.

Of course since this is a variable there might still be issues if the application manipulates it.