### PR TITLE
FreeSwitchClient make port option optional

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -52,7 +52,7 @@ export class FreeSwitchClient extends FreeSwitchEventEmitter<keyof FreeSwitchCli
    */
   constructor (options?: {
     host?: string
-    port: number
+    port?: number
     password?: string
     logger?: FreeSwitchClientLogger
   }) {


### PR DESCRIPTION
The default port is 8021, so it shouldn't be required to pass it to the constructor.