### PR TITLE
add Job-Owner-UUID to filter for myEvent

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -118,6 +118,7 @@ export class FreeSwitchServer extends FreeSwitchEventEmitter<keyof FreeSwitchSer
             if (myEvents) {
               // Restricting events using `filter` is required so that `event_json` will only obtain our events.
               await call.filter(Unique_ID, uuid)
+              await call.filter("Job-Owner-UUID", uuid)
             }
           }
           call.auto_cleanup()


### PR DESCRIPTION
Freeswitch doesn't seem to set the Unique-ID header for BACKGROUND_JOB events; rather it sets a header called Job-Owner-UUID to the call uuid for which the api command was executed.